### PR TITLE
[buster] Get rid of debian version specific/hardcoded stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 
 * x86-64b - [![Build Status](https://ci-apps.yunohost.org/ci/logs/collabora%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/collabora/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/collabora%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/collabora/)
-* Jessie x86-64b - [![Build Status](https://ci-stretch.nohost.me/ci/logs/collabora%20%28Apps%29.svg)](https://ci-stretch.nohost.me/ci/apps/collabora/)
 
 ## Limitations
 

--- a/scripts/install
+++ b/scripts/install
@@ -63,19 +63,17 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 #===============================================
 # ADD COLLABORA REPOSITORY
 #===============================================
+ynh_print_info --message="Add Collabora repository..."
 
-ynh_install_app_dependencies apt-transport-https
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
-
 DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
-echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./' | tee -a /etc/apt/sources.list.d/collabora.list
+echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
 
 #=================================================
 # INSTALL DEPENDENCIES
 #=================================================
 ynh_print_info --message="Installing dependencies..."
 
-ynh_package_update
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -67,12 +67,8 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 ynh_install_app_dependencies apt-transport-https
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
 
-if [ "$(lsb_release --codename --short)" = "jessie" ]; then
-echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian8 ./' | tee -a /etc/apt/sources.list.d/collabora.list
-else
-
-echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian9 ./' | tee -a /etc/apt/sources.list.d/collabora.list
-fi
+DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
+echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./' | tee -a /etc/apt/sources.list.d/collabora.list
 
 #=================================================
 # INSTALL DEPENDENCIES

--- a/scripts/remove
+++ b/scripts/remove
@@ -64,10 +64,10 @@ ynh_secure_remove --file="/etc/cron.d/$app"
 ynh_secure_remove --file="/etc/apt/sources.list.d/collabora.list"
 
 # Remove a directory securely
-ynh_secure_remove --file="/etc/loolwsd/"
+ynh_secure_remove --file="/etc/loolwsd"
 
 # Remove the log files
-ynh_secure_remove --file="/var/log/$app/"
+ynh_secure_remove --file="/var/log/$app"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -51,16 +51,11 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #===============================================
 # ADD COLLABORA REPOSITORY
 #===============================================
+ynh_print_info --message="Add Collabora repository..."
 
-ynh_install_app_dependencies apt-transport-https
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
-
-if [ "$(lsb_release --codename --short)" = "jessie" ]; then
-echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian8 ./' | tee -a /etc/apt/sources.list.d/collabora.list
-else
-
-echo 'deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian9 ./' | tee -a /etc/apt/sources.list.d/collabora.list
-fi
+DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
+echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
 
 #=================================================
 # REINSTALL DEPENDENCIES
@@ -68,7 +63,6 @@ fi
 ynh_print_info --message="Reinstalling dependencies..."
 
 # Define and install dependencies
-ynh_package_update
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,13 +74,22 @@ ynh_print_info --message="Upgrading nginx web server configuration..."
 # Create a dedicated nginx config
 ynh_add_nginx_config
 
+#===============================================
+# ADD COLLABORA REPOSITORY
+#===============================================
+ynh_print_info --message="Add Collabora repository..."
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
+DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
+echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
+
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
 ynh_print_info --message="Upgrading dependencies..."
 
-ynh_package_update
-ynh_install_app_dependencies loolwsd code-brand
+ynh_install_app_dependencies $pkg_dependencies
+
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================


### PR DESCRIPTION
## Problem

Install fails on buster, probably because assuming that if it's not debian jessie (sigh) it's stretch. But now it's buster.

## Solution

Have a version-agnostic snippet to add the right source.list file.

NB. : This is totally yolo commited and not tested at all (except for the small snippet that get the '8', '9' or '10')

## PR Status

- [X] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

Revision: 103d7e46c4cf3e430a0f83933321da32cafd9b89 
![image](https://user-images.githubusercontent.com/30271971/79494798-e278ce00-8023-11ea-861f-420a39d45395.png)

