### PR TITLE
Fix linter, use proper helper to install deps from custom deb repository

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A LibreOffice-based online office suite with collaborative editing",
         "fr": "Une suite office en ligne et collaborative, basée sur LibreOffice"
     },
-    "version": "4.0.0~ynh1",
+    "version": "4.0.0~ynh2",
     "url": "https://www.libreoffice.org/download/libreoffice-online/",
     "license": "MPL-2.0",
     "maintainer": {
@@ -15,7 +15,7 @@
         "url": "https://collaboraoffice.com"
     },
     "requirements": {
-        "yunohost": ">= 3.5"
+        "yunohost": ">= 3.8.1"
     },
     "multi_instance": false,
     "services": [
@@ -32,9 +32,7 @@
                 },
                 "example": "example.com"
             },
-           
-
-                                   {
+            {
                 "name": "password",
                 "type": "password",
                 "ask": {
@@ -42,9 +40,9 @@
                     "fr": "Choisissez un mot de passe pour l'administration de Collabora"
                 },
                 "example": "password"
-         
+
             },
-                                   {
+            {
                 "name": "nextcloud_domain",
                 "type": "string",
                 "ask": {
@@ -53,10 +51,10 @@
                 },
                 "example": "example.com",
                 "default": ""
-         
-                                   }
-         
-        
+
+            }
+
+
         ]
     }
 }

--- a/scripts/install
+++ b/scripts/install
@@ -63,18 +63,11 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 #===============================================
 # ADD COLLABORA REPOSITORY
 #===============================================
-ynh_print_info --message="Add Collabora repository..."
-
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
-DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
-echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
-
-#=================================================
-# INSTALL DEPENDENCIES
-#=================================================
 ynh_print_info --message="Installing dependencies..."
 
-ynh_install_app_dependencies $pkg_dependencies
+DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
+
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/install
+++ b/scripts/install
@@ -67,7 +67,7 @@ ynh_print_info --message="Installing dependencies..."
 
 DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
 
-ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./ " --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -55,7 +55,7 @@ ynh_print_info --message="Installing dependencies..."
 
 DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
 
-ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./ " --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # RESTORE CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -51,19 +51,11 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #===============================================
 # ADD COLLABORA REPOSITORY
 #===============================================
-ynh_print_info --message="Add Collabora repository..."
+ynh_print_info --message="Installing dependencies..."
 
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
 DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
-echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
 
-#=================================================
-# REINSTALL DEPENDENCIES
-#=================================================
-ynh_print_info --message="Reinstalling dependencies..."
-
-# Define and install dependencies
-ynh_install_app_dependencies $pkg_dependencies
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # RESTORE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -81,7 +81,7 @@ ynh_print_info --message="Upgrading dependencies..."
 
 DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
 
-ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./ " --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # SPECIFIC UPGRADE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -74,21 +74,14 @@ ynh_print_info --message="Upgrading nginx web server configuration..."
 # Create a dedicated nginx config
 ynh_add_nginx_config
 
-#===============================================
-# ADD COLLABORA REPOSITORY
-#===============================================
-ynh_print_info --message="Add Collabora repository..."
-
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0C54D189F4BA284D
-DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
-echo "deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" | tee -a /etc/apt/sources.list.d/collabora.list
-
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
 ynh_print_info --message="Upgrading dependencies..."
 
-ynh_install_app_dependencies $pkg_dependencies
+DEBIAN_VERSION_NUMBER=$(cat /etc/debian_version | head -n 1 | cut -f1 -d .)
+
+ynh_install_extra_app_dependencies --repo="deb https://collaboraoffice.com/repos/CollaboraOnline/CODE-debian${DEBIAN_VERSION_NUMBER} ./" --package="$pkg_dependencies" --key="https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D"
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem

Fix https://github.com/YunoHost-Apps/collabora_ynh/issues/15 , App level 4 because we shouldn't mess with sources.list manually

## Solution

Use the proper helper for this

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results

c.f. https://ci-apps-dev.yunohost.org/jenkins/job/collabora_ynh%20(aleks)/2/console

Test failed Installation in public mode but that looks like a random issue which should be adressed by another PR ... So far I don't understand why that happens and the logs are shit T_T

