### PR TITLE
Die with message if upgrade is impossible (#58)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "LibreOffice-based online office suite with collaborative editing",
         "fr": "Suite office en ligne et collaborative, basée sur LibreOffice"
     },
-    "version": "21.11.0.6~ynh1",
+    "version": "21.11.2.2~ynh1",
     "url": "https://collaboraoffice.com",
     "upstream": {
         "license": "MPL-2.0",

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -27,6 +27,11 @@ nextcloud_domain=$(ynh_app_setting_get --app="$app" --key=nextcloud_domain)
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=2
 
+if ynh_compare_current_package_version --comparison le --version 6.4.10~ynh2
+then
+	ynh_die --message="Upgrade from version 6.4.10 is not possible. You must uninstall and reinstall Collabora package manually"
+fi
+
 # If db_name doesn't exist, create it
 if [ -z "$path_url" ]; then
 	path_url="/"


### PR DESCRIPTION
## Problem

- When upgrading from version `6.4.10~ynh2`, the error is not clear and looks like a bug. No instruction is given about how to handle an upgrade from this version

## Solution

- If the current version is below or equal to `6.4.10~ynh2`, abort the upgrade and tell the user to uninstall and reinstall the collabora package 

**NB: Don't hesitate to nitpick, the clearer the abortion message is, the better.**

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
