### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -19,7 +19,7 @@ ynh_restore_file --origin_path="$install_dir"
 
 ### $install_dir will automatically be initialized with some decent
 ### permissions by default ... however, you may need to recursively reapply
-### ownership to all files such as after the ynh_setup_source step
+### ownership to all files such as after the ynh_setup_source step --full_replace=1
 chown -R "$app:www-data" "$install_dir"
 
 #=================================================


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```