### PR TITLE
Set client_max_body_size for /cool to avoid 413 on large documents

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -33,6 +33,10 @@ location ~ ^/cool/(.*)/ws$ {
 location ~ ^/(c|l)ool {
     proxy_pass http://localhost:__PORT__;
     include proxy_params_no_auth;
+    # Allow bodies larger than nginx's 1M default; otherwise uploads and
+    # conversions (e.g. Nextcloud office previews via /cool/convert-to)
+    # fail with "413 Request Entity Too Large"
+    client_max_body_size 100M;
     more_set_headers "X-Frame-Options: ALLOWALL";
 }
 


### PR DESCRIPTION
## Problem

The nginx config doesn't set `client_max_body_size`, so nginx's default of **1M** applies to the `/cool` endpoints. Any document larger than 1 MB that is POSTed to `/cool/convert-to/...` — which Nextcloud's richdocuments app uses to generate office file previews — is rejected by nginx with `413 Request Entity Too Large` before it ever reaches coolwsd. The same limit applies to image/file uploads during editing.

On my instance this produced dozens of these entries in the Nextcloud log:

```
Failed to convert preview: Client error: `POST https://collabora.example.org/cool/convert-to/png`
resulted in a `413 Request Entity Too Large` response
```

## Fix

Set `client_max_body_size 100M;` in the `location ~ ^/(c|l)ool` block (the "download, presentation and image upload" endpoint). 100M matches what other Collabora reverse-proxy setups commonly use and is far above typical document sizes while still bounded.

## Test

Verified on a YunoHost instance (Collabora 25.04.10.3, Nextcloud 34): before the change, `curl -F "data=@file.docx" https://<domain>/cool/convert-to/pdf` fails with 413 for files > 1 MB; after adding the directive and reloading nginx, the conversion succeeds and Nextcloud office previews are generated again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

